### PR TITLE
Send target_request to on_connect callback to allow for request modification before proxying

### DIFF
--- a/lib/reverse_proxy/client.rb
+++ b/lib/reverse_proxy/client.rb
@@ -86,7 +86,7 @@ module ReverseProxy
 
       # Make the request
       Net::HTTP.start(uri.hostname, uri.port, http_options) do |http|
-        callbacks[:on_connect].call(http)
+        callbacks[:on_connect].call(http, target_request)
         target_response = http.request(target_request)
       end
 


### PR DESCRIPTION
The `on_connect` callback should be passed `target_request` as well to allow for `target_request` to be modified before being sent over the connection.